### PR TITLE
Fixed empty buffer

### DIFF
--- a/src/scanner/ExtendedBluetoothDevice.ts
+++ b/src/scanner/ExtendedBluetoothDevice.ts
@@ -50,7 +50,7 @@ export class ExtendedBluetoothDevice {
   parkStatus: number = 0;
 
   constructor(id: string, name: string, rssi: number, manufacturerData: Buffer, device?: any) {
-    if(device) {
+    if (device) {
       this.device = device;
     }
     this.id = id;
@@ -94,6 +94,8 @@ export class ExtendedBluetoothDevice {
 
   parseManufacturerData(manufacturerData: Buffer) {
     // TODO: check offset is within the limits of the Buffer
+    // try {
+    console.log(manufacturerData, manufacturerData.length)
     var offset = 0;
     this.protocolType = manufacturerData.readInt8(offset++);
     this.protocolVersion = manufacturerData.readInt8(offset++);
@@ -193,6 +195,9 @@ export class ExtendedBluetoothDevice {
     });
     macArr.reverse();
     this.mAddress = macArr.join(':').toUpperCase();
+    // } catch (error) {
+    // console.log(error)
+    // }
   }
 
   getLockType(): LockType {

--- a/src/scanner/NobleScanner.ts
+++ b/src/scanner/NobleScanner.ts
@@ -97,9 +97,9 @@ export class NobleScanner extends events.EventEmitter implements ScannerInterfac
     const uuid = peripheral.uuid;
     const name = peripheral.advertisement.localName;
     const rssi = peripheral.rssi;
-    var manufacturerData = Buffer.from([]);
+    let manufacturerData = Buffer.from([]);
     if (peripheral.advertisement.manufacturerData) {
-      const manufacturerData = peripheral.advertisement.manufacturerData;
+      manufacturerData = peripheral.advertisement.manufacturerData;
     }
     const device = new ExtendedBluetoothDevice(id, name, rssi, manufacturerData, peripheral);
     device.uuid = uuid;


### PR DESCRIPTION
Fixes error `processLeAdvertisingReport: Caught illegal packet (buffer overflow): RangeError [ERR_BUFFER_OUT_OF_BOUNDS]: Attempt to access memory outside buffer bounds`

Now returns actual useful data, including battery percentage and stuff:

```
ExtendedBluetoothDevice {
  id: 'eec6a2049af6',
  uuid: 'eec6a2049af6',
  name: 'S202F_f69a04',
  mAddress: 'EE:C6:A2:4:9A:F6', <-- Now gets set, although "wrong", invalid MAC
  rssi: -74,
  protocolType: 5, <-- Set
  protocolVersion: 3, <-- Set
  scene: 2, <-- Set
  groupId: 0,
  orgId: 0,
  lockType: 5, <-- Set
  isTouch: true, <-- Set
  isSettingMode: false,
  isUnlock: false,
  txPowerLevel: 0,
  batteryCapacity: 74, <-- Set
  date: 0,
  isWristband: false,
  isRoomLock: true,
  isSafeLock: false,
  isBicycleLock: false,
  isLockcar: false,
  isGlassLock: false,
  isPadLock: false,
  isCyLinder: false,
  isRemoteControlDevice: false,
  isDfuMode: false,
  isNoLockService: false,
  remoteUnlockSwitch: 0,
  disconnectStatus: 0,
  parkStatus: 0,
  device: Peripheral {
    _noble: Noble {
      initialized: true,
      address: 'b8:27:eb:79:ef:5d',
      _state: 'poweredOn',
      _bindings: [NobleBindings],
      _peripherals: [Object],
      _services: [Object],
      _characteristics: [Object],
      _descriptors: [Object],
      _discoveredPeripheralUUids: [Array],
      _events: [Object: null prototype],
      _eventsCount: 6,
      _allowDuplicates: true
    },
    id: 'eec6a2049af6',
    uuid: 'eec6a2049af6',
    address: 'ee:c6:a2:04:9a:f6',
    addressType: 'public',
    connectable: true,
    advertisement: {
      localName: 'S202F_f69a04',
      txPowerLevel: -65,
      manufacturerData: <Buffer 05 03 02 10 4a b0 00 f4 f9 53 65 f6 9a 04 a2 c6 ee>,
      serviceData: [],
      serviceUuids: [Array],
      solicitationServiceUuids: [],
      serviceSolicitationUuids: []
    },
    rssi: -74,
    services: null,
    mtu: null,
    state: 'disconnected'
  }
}
^C
```