### PR TITLE
Add WebSocket support for noble

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ The goal of this project is to make a partial JavaScript port of the TTLock Andr
 - Some commands always have a bad CRC.
 - The SDK only works with locks that use the V3 protocol for communication.
 
+## Gateway option
+
+The websocket binding present in [@abandonware/noble](https://github.com/abandonware/noble) was extended with a simple authentication via AES key, user and password. This adds basic suport for using a bluetooth adapter on a remote host via a simple websocket connection. The end goal will be to run an ESP32 as a gateway (development ongoing) to extend the range of the device the SDK is running on, or maybe just use it on a device that does not even have a bluetooth adapter. A sample server is implemented in [tools/server.js](./tools/server.js). All examples in the SKD can be started in websocket mode by adding the following environment variables:
+- `WEBSOCKET_DEBUG=1`  - debug websocket messages
+- `WEBSOCKET_ENABLE=1` - this will enable websocket support
+- `WEBSOCKET_HOST=127.0.0.1` - the IP or hostname of the host running the server
+- `WEBSOCKET_PORT=2846` - the port the server is running on
+
+For example:
+```sh
+pi@raspberrypi:~/ttlock-sdk-js $ WEBSOCKET_ENABLE=1 WEBSOCKET_HOST=192.168.1.42 npm run get-cards
+```
+
 ## Sample usage of this SDK
 
 1. Clone the repo and install the dependencies `npm i`.

--- a/examples/addFR.js
+++ b/examples/addFR.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/addFR.js
+++ b/examples/addFR.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/addICCard.js
+++ b/examples/addICCard.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/addICCard.js
+++ b/examples/addICCard.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/addPassCode.js
+++ b/examples/addPassCode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/addPassCode.js
+++ b/examples/addPassCode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/clearFR.js
+++ b/examples/clearFR.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/clearFR.js
+++ b/examples/clearFR.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/clearICCards.js
+++ b/examples/clearICCards.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/clearICCards.js
+++ b/examples/clearICCards.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/clearPassCodes.js
+++ b/examples/clearPassCodes.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/clearPassCodes.js
+++ b/examples/clearPassCodes.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/clearPassageMode.js
+++ b/examples/clearPassageMode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/clearPassageMode.js
+++ b/examples/clearPassageMode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/deletePassCode.js
+++ b/examples/deletePassCode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/deletePassCode.js
+++ b/examples/deletePassCode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/deletePassageMode.js
+++ b/examples/deletePassageMode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/deletePassageMode.js
+++ b/examples/deletePassageMode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/getFR.js
+++ b/examples/getFR.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/getFR.js
+++ b/examples/getFR.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/getICCards.js
+++ b/examples/getICCards.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/getICCards.js
+++ b/examples/getICCards.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/getPassCodes.js
+++ b/examples/getPassCodes.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/getPassCodes.js
+++ b/examples/getPassCodes.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/getPassageMode.js
+++ b/examples/getPassageMode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/getPassageMode.js
+++ b/examples/getPassageMode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/init.js
+++ b/examples/init.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/init.js
+++ b/examples/init.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   for (let i = 10; i > 0; i--) {
     console.log("Starting scan...", i);

--- a/examples/listen.js
+++ b/examples/listen.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/listen.js
+++ b/examples/listen.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/lock.js
+++ b/examples/lock.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/lock.js
+++ b/examples/lock.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/reset.js
+++ b/examples/reset.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/reset.js
+++ b/examples/reset.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/setPassageMode.js
+++ b/examples/setPassageMode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/setPassageMode.js
+++ b/examples/setPassageMode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/status.js
+++ b/examples/status.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/status.js
+++ b/examples/status.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");
@@ -29,7 +40,11 @@ async function doStuff() {
       console.log();
       const result = await lock.getLockStatus();
       if (result != -1) {
-        console.log("Lock is locked", result);
+        if (result == 0) {
+          console.log("Lock is locked", result);
+        } else {
+          console.log("Lock is unlocked", result);
+        }
       } else {
         console.log("Failed to get lock status");
       }

--- a/examples/unlock.js
+++ b/examples/unlock.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/unlock.js
+++ b/examples/unlock.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/examples/updatePassCode.js
+++ b/examples/updatePassCode.js
@@ -12,9 +12,20 @@ async function doStuff() {
     lockData = JSON.parse(lockDataTxt);
   } catch (error) {}
 
-  const client = new TTLockClient({
-    lockData: lockData
-  });
+  let options = {
+    lockData: lockData,
+    scannerType: "noble",
+    scannerOptions: {
+      websocketPort: 0xB1e
+    },
+    // uuids: []
+  };
+
+  if (process.env.WEBSOCKET_ENABLE == 1) {
+    options.scannerType = "noble-websocket";
+  }
+
+  const client = new TTLockClient(options);
   await client.prepareBTService();
   client.startScanLock();
   console.log("Scan started");

--- a/examples/updatePassCode.js
+++ b/examples/updatePassCode.js
@@ -16,13 +16,20 @@ async function doStuff() {
     lockData: lockData,
     scannerType: "noble",
     scannerOptions: {
-      websocketPort: 0xB1e
+      websocketHost: "127.0.0.1",
+      websocketPort: 2846
     },
     // uuids: []
   };
 
-  if (process.env.WEBSOCKET_ENABLE == 1) {
+  if (process.env.WEBSOCKET_ENABLE == "1") {
     options.scannerType = "noble-websocket";
+    if (process.env.WEBSOCKET_HOST) {
+      options.scannerOptions.websocketHost = process.env.WEBSOCKET_HOST;
+    }
+    if (process.env.WEBSOCKET_PORT) {
+      options.scannerOptions.websocketPort = process.env.WEBSOCKET_PORT;
+    }
   }
 
   const client = new TTLockClient(options);

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "add-fingerprint": "npm run build && node ./examples/addFR.js",
     "get-fingerprints": "npm run build && node ./examples/getFR.js",
     "clear-fingerprints": "npm run build && node ./examples/clearFR.js",
-    "listen": "npm run build && node ./examples/listen.js",
-    "debug-tool": "npm run build && NOBLE_REPORT_ALL_HCI_EVENTS=1 node ./tools/dedbug.js"
+    "listen": "npm run build && node --trace-warnings ./examples/listen.js",
+    "debug-tool": "npm run build && NOBLE_REPORT_ALL_HCI_EVENTS=1 node ./tools/dedbug.js",
+    "server-tool": "NOBLE_REPORT_ALL_HCI_EVENTS=1 node ./tools/server.js"
   },
   "repository": {
     "type": "git",
@@ -56,11 +57,13 @@
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7",
     "@types/node": "^14.14.8",
+    "@types/ws": "^7.4.0",
     "tslint": "^6.1.3",
     "typescript": "^4.0.5"
   },
   "dependencies": {
     "@abandonware/noble": "^1.9.2-10",
-    "moment": "^2.29.1"
+    "moment": "^2.29.1",
+    "ws": "^7.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "homepage": "https://github.com/kind3r/ttlock-sdk-js#readme",
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7",
+    "@types/crypto-js": "^4.0.1",
     "@types/node": "^14.14.8",
     "@types/ws": "^7.4.0",
     "tslint": "^6.1.3",
@@ -63,6 +64,7 @@
   },
   "dependencies": {
     "@abandonware/noble": "^1.9.2-10",
+    "crypto-js": "^4.0.0",
     "moment": "^2.29.1",
     "ws": "^7.4.2"
   }

--- a/src/TTLockClient.ts
+++ b/src/TTLockClient.ts
@@ -6,12 +6,14 @@ import { TTBluetoothDevice } from "./device/TTBluetoothDevice";
 import { TTLock } from "./device/TTLock";
 
 import { BluetoothLeService, TTLockUUIDs, ScannerType } from "./scanner/BluetoothLeService";
+import { ScannerOptions } from "./scanner/ScannerInterface";
 import { TTLockData } from "./store/TTLockData";
 import { sleep } from "./util/timingUtil";
 
 export interface Settings {
   uuids?: string[];
   scannerType?: ScannerType;
+  scannerOptions?: ScannerOptions;
   lockData?: TTLockData[];
 }
 
@@ -25,6 +27,7 @@ export class TTLockClient extends events.EventEmitter implements TTLockClient {
   bleService: BluetoothLeService | null = null;
   uuids: string[];
   scannerType: ScannerType = "noble";
+  scannerOptions: ScannerOptions;
   lockData: Map<string, TTLockData>;
   private adapterReady: boolean;
 
@@ -39,8 +42,14 @@ export class TTLockClient extends events.EventEmitter implements TTLockClient {
       this.uuids = TTLockUUIDs;
     }
 
-    if (options.scannerType) {
+    if (typeof options.scannerType != "undefined") {
       this.scannerType = options.scannerType;
+    }
+
+    if (typeof options.scannerOptions != "undefined") {
+      this.scannerOptions = options.scannerOptions;
+    } else {
+      this.scannerOptions = {};
     }
 
     this.lockData = new Map();
@@ -53,7 +62,7 @@ export class TTLockClient extends events.EventEmitter implements TTLockClient {
 
   async prepareBTService(): Promise<boolean> {
     if (this.bleService == null) {
-      this.bleService = new BluetoothLeService(this.uuids, this.scannerType);
+      this.bleService = new BluetoothLeService(this.uuids, this.scannerType, this.scannerOptions);
       this.bleService.on("ready", () => this.adapterReady = true);
       this.bleService.on("discover", this.onScanResult.bind(this));
       this.bleService.on("scanStart", () => this.emit("scanStart"));

--- a/src/scanner/BluetoothLeService.ts
+++ b/src/scanner/BluetoothLeService.ts
@@ -27,7 +27,12 @@ export class BluetoothLeService extends EventEmitter implements BluetoothLeServi
     if (scannerType == "noble") {
       this.scanner = new NobleScanner(uuids);
     } else if (scannerType == "noble-websocket") {
-      this.scanner = new NobleScannerWebsocket(uuids, scannerOptions.websocketHost, scannerOptions.websocketPort);
+      this.scanner = new NobleScannerWebsocket(uuids, 
+        scannerOptions.websocketHost, 
+        scannerOptions.websocketPort,
+        scannerOptions.websocketAesKey,
+        scannerOptions.websocketUsername,
+        scannerOptions.websocketPassword);
     } else {
       throw "Invalid parameters";
     }

--- a/src/scanner/BluetoothLeService.ts
+++ b/src/scanner/BluetoothLeService.ts
@@ -1,10 +1,11 @@
 'use strict';
 
 import { EventEmitter } from "events";
-import { ScannerInterface, ScannerType } from "./ScannerInterface";
+import { ScannerInterface, ScannerOptions, ScannerType } from "./ScannerInterface";
 import { NobleScanner } from "./noble/NobleScanner";
 import { TTBluetoothDevice } from "../device/TTBluetoothDevice";
 import { DeviceInterface } from "./DeviceInterface";
+import { NobleScannerWebsocket } from "./noble/NobleScannerWebsocket";
 
 export { ScannerType } from "./ScannerInterface";
 export const TTLockUUIDs: string[] = ["1910", "00001910-0000-1000-8000-00805f9b34fb"];
@@ -20,21 +21,20 @@ export class BluetoothLeService extends EventEmitter implements BluetoothLeServi
   private scanner: ScannerInterface;
   private devices: Map<string, TTBluetoothDevice>;
 
-  constructor(uuids: string[] = TTLockUUIDs, scannerType: ScannerType = "auto") {
+  constructor(uuids: string[] = TTLockUUIDs, scannerType: ScannerType = "noble", scannerOptions: ScannerOptions) {
     super();
     this.devices = new Map();
-    if (scannerType == "auto") {
-      scannerType = "noble";
-    }
     if (scannerType == "noble") {
       this.scanner = new NobleScanner(uuids);
-      this.scanner.on("ready", () => this.emit("ready"));
-      this.scanner.on("discover", this.onDiscover.bind(this));
-      this.scanner.on("scanStart", () => this.emit("scanStart"));
-      this.scanner.on("scanStop", () => this.emit("scanStop"));
+    } else if (scannerType == "noble-websocket") {
+      this.scanner = new NobleScannerWebsocket(uuids, scannerOptions.websocketHost, scannerOptions.websocketPort);
     } else {
       throw "Invalid parameters";
     }
+    this.scanner.on("ready", () => this.emit("ready"));
+    this.scanner.on("discover", this.onDiscover.bind(this));
+    this.scanner.on("scanStart", () => this.emit("scanStart"));
+    this.scanner.on("scanStop", () => this.emit("scanStop"));
   }
 
   async startScan(): Promise<boolean> {

--- a/src/scanner/ScannerInterface.ts
+++ b/src/scanner/ScannerInterface.ts
@@ -3,7 +3,12 @@
 import { EventEmitter } from "events";
 import { DeviceInterface } from "./DeviceInterface";
 
-export type ScannerType = "noble" | "node-ble" | "auto";
+export type ScannerType = "noble" | "noble-websocket";
+
+export type ScannerOptions = {
+  websocketHost?: string,
+  websocketPort?: number
+}
 
 export type ScannerStateType = "unknown" | "starting" | "scanning" | "stopping" | "stopped";
 

--- a/src/scanner/ScannerInterface.ts
+++ b/src/scanner/ScannerInterface.ts
@@ -7,7 +7,10 @@ export type ScannerType = "noble" | "noble-websocket";
 
 export type ScannerOptions = {
   websocketHost?: string,
-  websocketPort?: number
+  websocketPort?: number,
+  websocketAesKey?: string,
+  websocketUsername?: string,
+  websocketPassword?: string
 }
 
 export type ScannerStateType = "unknown" | "starting" | "scanning" | "stopping" | "stopped";

--- a/src/scanner/noble/NobleScannerWebsocket.ts
+++ b/src/scanner/noble/NobleScannerWebsocket.ts
@@ -16,6 +16,10 @@ export class NobleScannerWebsocket extends NobleScanner {
     this.initNoble();
   }
 
+  protected createNoble() {
+    
+  }
+
   protected createNobleWebsocket() {
     const binding = new NobleWebsocketBinding(this.websocketAddress, this.websocketPort);
     this.noble = new Noble(binding);

--- a/src/scanner/noble/NobleScannerWebsocket.ts
+++ b/src/scanner/noble/NobleScannerWebsocket.ts
@@ -7,21 +7,27 @@ const Noble = require("@abandonware/noble/with-bindings");
 export class NobleScannerWebsocket extends NobleScanner {
   private websocketAddress: string;
   private websocketPort: number;
+  private aesKey: string;
+  private username: string;
+  private password: string;
 
-  constructor(uuids: string[] = [], address: string = "127.0.0.1", port: number = 80) {
-    super(uuids);
-    this.websocketAddress = address;
-    this.websocketPort = port;
+  constructor(uuids?: string[], address?: string, port?: number, aesKey?: string, username?: string, password?: string) {
+    super(uuids || []);
+    this.websocketAddress = address || "127.0.0.1";
+    this.websocketPort = port || 80;
+    this.aesKey = aesKey || "f8b55c272eb007f501560839be1f1e7e";
+    this.username = username || "admin";
+    this.password = password || "admin";
     this.createNobleWebsocket();
     this.initNoble();
   }
 
   protected createNoble() {
-    
+
   }
 
   protected createNobleWebsocket() {
-    const binding = new NobleWebsocketBinding(this.websocketAddress, this.websocketPort);
+    const binding = new NobleWebsocketBinding(this.websocketAddress, this.websocketPort, this.aesKey, this.username, this.password);
     this.noble = new Noble(binding);
   }
 }

--- a/src/scanner/noble/NobleScannerWebsocket.ts
+++ b/src/scanner/noble/NobleScannerWebsocket.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import { NobleScanner } from "./NobleScanner";
+import { NobleWebsocketBinding } from "./NobleWebsocketBinding";
+const Noble = require("@abandonware/noble/with-bindings");
+
+export class NobleScannerWebsocket extends NobleScanner {
+  private websocketAddress: string;
+  private websocketPort: number;
+
+  constructor(uuids: string[] = [], address: string = "127.0.0.1", port: number = 80) {
+    super(uuids);
+    this.websocketAddress = address;
+    this.websocketPort = port;
+    this.createNobleWebsocket();
+    this.initNoble();
+  }
+
+  protected createNobleWebsocket() {
+    const binding = new NobleWebsocketBinding(this.websocketAddress, this.websocketPort);
+    this.noble = new Noble(binding);
+  }
+}

--- a/src/scanner/noble/NobleWebsocketBinding.ts
+++ b/src/scanner/noble/NobleWebsocketBinding.ts
@@ -54,7 +54,7 @@ export class NobleWebsocketBinding extends EventEmitter {
     this.aesKey = CryptoJS.enc.Hex.parse(key);
     this.credentials = user + ':' + pass;
 
-    this.ws = new WebSocket(`ws://${address}:${port}`);
+    this.ws = new WebSocket(`ws://${address}:${port}/noble`);
 
     this.startScanCommand = null;
     this.peripherals = new Map();
@@ -66,7 +66,14 @@ export class NobleWebsocketBinding extends EventEmitter {
     this.ws.on('error', this.onClose.bind(this));
 
     this.ws.on('message', (data: WebSocket.Data) => {
-      this.emit('message', JSON.parse(data.toString()));
+      try {
+        if (process.env.WEBSOCKET_DEBUG == "1") {
+          console.log("Received:", data.toString());
+        }
+        this.emit('message', JSON.parse(data.toString()));
+      } catch (error) {
+        console.error(error);
+      }
     });
   }
 
@@ -84,9 +91,6 @@ export class NobleWebsocketBinding extends EventEmitter {
   }
 
   private onMessage(event: WsEvent) {
-    if (process.env.WEBSOCKET_DEBUG == "1") {
-      console.log('receive:', event);
-    }
     let {
       type,
       peripheralUuid,
@@ -187,6 +191,10 @@ export class NobleWebsocketBinding extends EventEmitter {
         console.warn('could not send command', command, error);
         if (typeof errorCallback === 'function') {
           errorCallback(error);
+        }
+      } else {
+        if (process.env.WEBSOCKET_DEBUG == "1") {
+          console.log("Sent:", message);
         }
       }
     });

--- a/src/scanner/noble/NobleWebsocketBinding.ts
+++ b/src/scanner/noble/NobleWebsocketBinding.ts
@@ -1,0 +1,389 @@
+'use strict';
+
+import { EventEmitter } from "events";
+import WebSocket from "ws";
+
+type Peripheral = {
+  uuid: string,
+  address: string,
+  advertisement?: any,
+  rssi: number
+}
+
+type WsAdvertisement = {
+  localName: string,
+  txPowerLevel: number,
+  serviceUuids: string,
+  manufacturerData?: string,
+  serviceData?: string
+}
+
+type WsEvent = {
+  type: string,
+  peripheralUuid: string,
+  address: string,
+  addressType: string,
+  connectable: string,
+  advertisement?: WsAdvertisement,
+  rssi: number,
+  serviceUuids: string,
+  serviceUuid: string,
+  includedServiceUuids: string,
+  characteristics: string,
+  characteristicUuid: string,
+  isNotification: boolean,
+  state: string,
+  descriptors: string,
+  descriptorUuid: string,
+  handle: string,
+  data?: string
+}
+
+export class NobleWebsocketBinding extends EventEmitter {
+  private ws: WebSocket;
+  private startScanCommand: any | null;
+  private peripherals: Map<string, Peripheral>;
+
+  constructor(address: string, port: number = 0xB1e) {
+    super();
+    this.ws = new WebSocket(`ws://${address}:${port}`);
+
+    this.startScanCommand = null;
+    this.peripherals = new Map();
+
+    this.on('message', this.onMessage.bind(this));
+
+    // if (!this.ws.on) {
+    //   this.ws.on = this.ws.addEventListener;
+    // }
+
+    this.ws.on('open', this.onOpen.bind(this));
+    this.ws.on('close', this.onClose.bind(this));
+    this.ws.on('error', this.onClose.bind(this));
+
+    this.ws.on('message', (data: WebSocket.Data) => {
+      this.emit('message', JSON.parse(data.toString()));
+    });
+  }
+
+  init() {
+
+  }
+
+  private onOpen() {
+    console.log('on -> open');
+  }
+
+  private onClose() {
+    console.log('on -> close');
+    this.emit('stateChange', 'poweredOff');
+  }
+
+  private onMessage(event: WsEvent) {
+    console.log('receive:', event);
+    let {
+      type,
+      peripheralUuid,
+      address,
+      addressType,
+      connectable,
+      advertisement,
+      rssi,
+      serviceUuids,
+      serviceUuid,
+      includedServiceUuids,
+      characteristics,
+      characteristicUuid,
+      isNotification,
+      state,
+      descriptors,
+      descriptorUuid,
+      handle
+    } = event;
+    const data = event.data ? Buffer.from(event.data, 'hex') : null;
+
+    if (type === 'stateChange') {
+      console.log(state);
+      this.emit('stateChange', state);
+    } else if (type === 'discover') {
+      if (typeof advertisement != "undefined") {
+        const advertisementObj = {
+          localName: advertisement.localName,
+          txPowerLevel: advertisement.txPowerLevel,
+          serviceUuids: advertisement.serviceUuids,
+          manufacturerData: (advertisement.manufacturerData ? Buffer.from(advertisement.manufacturerData, 'hex') : null),
+          serviceData: (advertisement.serviceData ? Buffer.from(advertisement.serviceData, 'hex') : null)
+        };
+
+        this.peripherals.set(peripheralUuid, {
+          uuid: peripheralUuid,
+          address: address,
+          advertisement: advertisementObj,
+          rssi: rssi
+        });
+
+        this.emit('discover', peripheralUuid, address, addressType, connectable, advertisementObj, rssi);
+      }
+    } else if (type === 'connect') {
+      this.emit('connect', peripheralUuid);
+    } else if (type === 'disconnect') {
+      this.emit('disconnect', peripheralUuid);
+    } else if (type === 'rssiUpdate') {
+      this.emit('rssiUpdate', peripheralUuid, rssi);
+    } else if (type === 'servicesDiscover') {
+      this.emit('servicesDiscover', peripheralUuid, serviceUuids);
+    } else if (type === 'includedServicesDiscover') {
+      this.emit('includedServicesDiscover', peripheralUuid, serviceUuid, includedServiceUuids);
+    } else if (type === 'characteristicsDiscover') {
+      this.emit('characteristicsDiscover', peripheralUuid, serviceUuid, characteristics);
+    } else if (type === 'read') {
+      this.emit('read', peripheralUuid, serviceUuid, characteristicUuid, data, isNotification);
+    } else if (type === 'write') {
+      this.emit('write', peripheralUuid, serviceUuid, characteristicUuid);
+    } else if (type === 'broadcast') {
+      this.emit('broadcast', peripheralUuid, serviceUuid, characteristicUuid, state);
+    } else if (type === 'notify') {
+      this.emit('notify', peripheralUuid, serviceUuid, characteristicUuid, state);
+    } else if (type === 'descriptorsDiscover') {
+      this.emit('descriptorsDiscover', peripheralUuid, serviceUuid, characteristicUuid, descriptors);
+    } else if (type === 'valueRead') {
+      this.emit('valueRead', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid, data);
+    } else if (type === 'valueWrite') {
+      this.emit('valueWrite', peripheralUuid, serviceUuid, characteristicUuid, descriptorUuid);
+    } else if (type === 'handleRead') {
+      this.emit('handleRead', peripheralUuid, handle, data);
+    } else if (type === 'handleWrite') {
+      this.emit('handleWrite', peripheralUuid, handle);
+    } else if (type === 'handleNotify') {
+      this.emit('handleNotify', peripheralUuid, handle, data);
+    }
+  }
+
+  private sendCommand(command: any, errorCallback?: any) {
+    const message = JSON.stringify(command);
+    this.ws.send(message, error => {
+      if (error != null) {
+        console.warn('could not send command', command, error);
+        if (typeof errorCallback === 'function') {
+          errorCallback(error);
+        }
+      }
+    });
+  }
+
+  startScanning(serviceUuids: string[], allowDuplicates: boolean = true) {
+    this.startScanCommand = {
+      action: 'startScanning',
+      serviceUuids: serviceUuids,
+      allowDuplicates: allowDuplicates
+    };
+    this.sendCommand(this.startScanCommand);
+
+    this.emit('scanStart');
+  }
+
+  stopScanning() {
+    this.startScanCommand = null;
+
+    this.sendCommand({
+      action: 'stopScanning'
+    });
+
+    this.emit('scanStop');
+  }
+
+  connect(deviceUuid: string) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'connect',
+        peripheralUuid: peripheral.uuid
+      });
+    }
+  }
+
+  disconnect(deviceUuid: string) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'disconnect',
+        peripheralUuid: peripheral.uuid
+      });
+    }
+  }
+
+  updateRssi(deviceUuid: string) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'updateRssi',
+        peripheralUuid: peripheral.uuid
+      });
+    }
+  }
+
+  discoverServices(deviceUuid: string, uuids: string[]) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'discoverServices',
+        peripheralUuid: peripheral.uuid,
+        uuids: uuids
+      });
+    }
+  }
+
+  discoverIncludedServices(deviceUuid: string, serviceUuid: string, serviceUuids: string[]) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'discoverIncludedServices',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        serviceUuids: serviceUuids
+      });
+    }
+  }
+
+  discoverCharacteristics(deviceUuid: string, serviceUuid: string, characteristicUuids: string[]) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'discoverCharacteristics',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuids: characteristicUuids
+      });
+    }
+  }
+
+  read(deviceUuid: string, serviceUuid: string, characteristicUuid: string) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'read',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid
+      });
+    }
+  }
+
+  write(deviceUuid: string, serviceUuid: string, characteristicUuid: string, data: Buffer, withoutResponse: boolean) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'write',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid,
+        data: data.toString('hex'),
+        withoutResponse: withoutResponse
+      });
+    }
+  }
+
+  broadcast(deviceUuid: string, serviceUuid: string, characteristicUuid: string, broadcast: any) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'broadcast',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid,
+        broadcast: broadcast
+      });
+    }
+  }
+
+  notify(deviceUuid: string, serviceUuid: string, characteristicUuid: string, notify: any) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'notify',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid,
+        notify: notify
+      });
+    }
+  }
+
+  discoverDescriptors(deviceUuid: string, serviceUuid: string, characteristicUuid: string) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'discoverDescriptors',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid,
+      });
+    }
+  }
+
+  readValue(deviceUuid: string, serviceUuid: string, characteristicUuid: string, descriptorUuid: string) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'readValue',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid,
+        descriptorUuid: descriptorUuid
+      });
+    }
+  }
+
+  writeValue(deviceUuid: string, serviceUuid: string, characteristicUuid: string, descriptorUuid: string, data: Buffer) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'writeValue',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: serviceUuid,
+        characteristicUuid: characteristicUuid,
+        descriptorUuid: descriptorUuid,
+        data: data.toString('hex')
+      });
+    }
+  }
+
+  readHandle(deviceUuid: string, handle: any) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'readHandle',
+        peripheralUuid: peripheral.uuid,
+        handle: handle
+      });
+    }
+  }
+
+  writeHandle(deviceUuid: string, handle: any, data: Buffer, withoutResponse: boolean) {
+    const peripheral = this.peripherals.get(deviceUuid);
+
+    if (typeof peripheral != "undefined") {
+      this.sendCommand({
+        action: 'writeHandle',
+        peripheralUuid: peripheral.uuid,
+        handle: handle,
+        data: data.toString('hex'),
+        withoutResponse: withoutResponse
+      });
+    }
+  }
+}

--- a/src/scanner/noble/NobleWebsocketBinding.ts
+++ b/src/scanner/noble/NobleWebsocketBinding.ts
@@ -80,7 +80,9 @@ export class NobleWebsocketBinding extends EventEmitter {
   }
 
   private onMessage(event: WsEvent) {
-    console.log('receive:', event);
+    if (process.env.WEBSOCKET_DEBUG == "1") {
+      console.log('receive:', event);
+    }
     let {
       type,
       peripheralUuid,

--- a/tools/server.js
+++ b/tools/server.js
@@ -4,7 +4,7 @@ var WebSocket = require('ws');
 var noble = require('@abandonware/noble');
 
 var serverMode = !process.argv[2];
-var port = 0xB1e;
+var port = process.env.WEBSOCKET_PORT || 2846;
 var host = process.argv[2];
 
 var ws;
@@ -14,7 +14,7 @@ var wss;
 if (serverMode) {
   console.log('noble - ws slave - server mode');
   wss = new WebSocket.Server({
-    port: 0xB1e
+    port: port
   });
 
   wss.on('connection', function (ws_) {

--- a/tools/server.js
+++ b/tools/server.js
@@ -18,11 +18,7 @@ wss.on('connection', function (ws) {
   console.log('ws -> connection');
 
   ws.isAuthenticated = false;
-  const authChallenge = Buffer.alloc(16);
-  for (let i = 0 ; i < 16 ; i++) {
-    authChallenge.writeUInt8(Math.round(Math.random() * 255), i);
-  }
-  ws.authChallenge = authChallenge.toString('hex');
+  ws.authChallenge = CryptoJS.lib.WordArray.random(16).toString(CryptoJS.enc.Hex);
 
   ws.on('message', (message) => {
     onMessage(ws, message);

--- a/tools/server.js
+++ b/tools/server.js
@@ -1,0 +1,405 @@
+/* jshint loopfunc: true */
+var WebSocket = require('ws');
+
+var noble = require('@abandonware/noble');
+
+var serverMode = !process.argv[2];
+var port = 0xB1e;
+var host = process.argv[2];
+
+var ws;
+/** @type {WebSocket.Server} */
+var wss;
+
+if (serverMode) {
+  console.log('noble - ws slave - server mode');
+  wss = new WebSocket.Server({
+    port: 0xB1e
+  });
+
+  wss.on('connection', function (ws_) {
+    console.log('ws -> connection');
+
+    ws = ws_;
+
+    ws.on('message', onMessage);
+
+    ws.on('close', function () {
+      console.log('ws -> close');
+      noble.stopScanning();
+    });
+
+    noble.on('stateChange', function (state) {
+      sendEvent({
+        type: 'stateChange',
+        state: state
+      });
+    });
+
+    // Send poweredOn if already in this state.
+    if (noble.state === 'poweredOn') {
+      sendEvent({
+        type: 'stateChange',
+        state: 'poweredOn'
+      });
+    }
+  });
+} else {
+  ws = new WebSocket('ws://' + host + ':' + port);
+
+  ws.on('open', function () {
+    console.log('ws -> open');
+  });
+
+  ws.on('message', function (message) {
+    onMessage(message);
+  });
+
+  ws.on('close', function () {
+    console.log('ws -> close');
+
+    noble.stopScanning();
+  });
+}
+
+var peripherals = {};
+
+// TODO: open/close ws on state change
+
+function sendEvent (event) {
+  var message = JSON.stringify(event);
+
+  console.log('ws -> send: ' + message);
+
+  var clients = serverMode ? wss.clients : new Set([ws]);
+
+  for (let client of clients) {
+    client.send(message);
+  }
+}
+
+var onMessage = function (message) {
+  console.log('ws -> message: ' + message);
+
+  var command = JSON.parse(message);
+
+  var action = command.action;
+  var peripheralUuid = command.peripheralUuid;
+  var serviceUuids = command.serviceUuids;
+  var serviceUuid = command.serviceUuid;
+  var characteristicUuids = command.characteristicUuids;
+  var characteristicUuid = command.characteristicUuid;
+  var data = command.data ? Buffer.from(command.data, 'hex') : null;
+  var withoutResponse = command.withoutResponse;
+  var broadcast = command.broadcast;
+  var notify = command.notify;
+  var descriptorUuid = command.descriptorUuid;
+  var handle;
+
+  var peripheral = peripherals[peripheralUuid];
+  var service = null;
+  var characteristic = null;
+  var descriptor = null;
+
+  if (peripheral && serviceUuid) {
+    var services = peripheral.services;
+
+    for (var i in services) {
+      if (services[i].uuid === serviceUuid) {
+        service = services[i];
+
+        if (characteristicUuid) {
+          var characteristics = service.characteristics;
+
+          for (var j in characteristics) {
+            if (characteristics[j].uuid === characteristicUuid) {
+              characteristic = characteristics[j];
+
+              if (descriptorUuid) {
+                var descriptors = characteristic.descriptors;
+
+                for (var k in descriptors) {
+                  if (descriptors[k].uuid === descriptorUuid) {
+                    descriptor = descriptors[k];
+                    break;
+                  }
+                }
+              }
+              break;
+            }
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  if (action === 'startScanning') {
+    noble.startScanning(serviceUuids, command.allowDuplicates);
+  } else if (action === 'stopScanning') {
+    noble.stopScanning();
+  } else if (action === 'connect') {
+    peripheral.connect();
+  } else if (action === 'disconnect') {
+    peripheral.disconnect();
+  } else if (action === 'updateRssi') {
+    peripheral.updateRssi();
+  } else if (action === 'discoverServices') {
+    peripheral.discoverServices(command.uuids);
+  } else if (action === 'discoverIncludedServices') {
+    service.discoverIncludedServices(serviceUuids);
+  } else if (action === 'discoverCharacteristics') {
+    service.discoverCharacteristics(characteristicUuids);
+  } else if (action === 'read') {
+    characteristic.read();
+  } else if (action === 'write') {
+    characteristic.write(data, withoutResponse);
+  } else if (action === 'broadcast') {
+    characteristic.broadcast(broadcast);
+  } else if (action === 'notify') {
+    characteristic.notify(notify);
+  } else if (action === 'discoverDescriptors') {
+    characteristic.discoverDescriptors();
+  } else if (action === 'readValue') {
+    descriptor.readValue();
+  } else if (action === 'writeValue') {
+    descriptor.writeValue(data);
+  } else if (action === 'readHandle') {
+    peripheral.readHandle(handle);
+  } else if (action === 'writeHandle') {
+    peripheral.writeHandle(handle, data, withoutResponse);
+  }
+};
+
+noble.on('discover', function (peripheral) {
+  peripherals[peripheral.uuid] = peripheral;
+
+  peripheral.on('connect', function () {
+    sendEvent({
+      type: 'connect',
+      peripheralUuid: this.uuid
+    });
+  });
+
+  peripheral.on('disconnect', function () {
+    sendEvent({
+      type: 'disconnect',
+      peripheralUuid: this.uuid
+    });
+
+    for (var i in this.services) {
+      for (var j in this.services[i].characteristics) {
+        for (var k in this.services[i].characteristics[j].descriptors) {
+          this.services[i].characteristics[j].descriptors[k].removeAllListeners();
+        }
+
+        this.services[i].characteristics[j].removeAllListeners();
+      }
+      this.services[i].removeAllListeners();
+    }
+
+    this.removeAllListeners();
+  });
+
+  peripheral.on('rssiUpdate', function (rssi) {
+    sendEvent({
+      type: 'rssiUpdate',
+      peripheralUuid: this.uuid,
+      rssi: rssi
+    });
+  });
+
+  peripheral.on('servicesDiscover', function (services) {
+    var peripheral = this;
+    var serviceUuids = [];
+
+    var includedServicesDiscover = function (includedServiceUuids) {
+      sendEvent({
+        type: 'includedServicesDiscover',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: this.uuid,
+        includedServiceUuids: includedServiceUuids
+      });
+    };
+
+    var characteristicsDiscover = function (characteristics) {
+      var service = this;
+      var discoveredCharacteristics = [];
+
+      var read = function (data, isNotification) {
+        var characteristic = this;
+
+        sendEvent({
+          type: 'read',
+          peripheralUuid: peripheral.uuid,
+          serviceUuid: service.uuid,
+          characteristicUuid: characteristic.uuid,
+          data: data.toString('hex'),
+          isNotification: isNotification
+        });
+      };
+
+      var write = function () {
+        var characteristic = this;
+
+        sendEvent({
+          type: 'write',
+          peripheralUuid: peripheral.uuid,
+          serviceUuid: service.uuid,
+          characteristicUuid: characteristic.uuid
+        });
+      };
+
+      var broadcast = function (state) {
+        var characteristic = this;
+
+        sendEvent({
+          type: 'broadcast',
+          peripheralUuid: peripheral.uuid,
+          serviceUuid: service.uuid,
+          characteristicUuid: characteristic.uuid,
+          state: state
+        });
+      };
+
+      var notify = function (state) {
+        var characteristic = this;
+
+        sendEvent({
+          type: 'notify',
+          peripheralUuid: peripheral.uuid,
+          serviceUuid: service.uuid,
+          characteristicUuid: characteristic.uuid,
+          state: state
+        });
+      };
+
+      var descriptorsDiscover = function (descriptors) {
+        var characteristic = this;
+
+        var discoveredDescriptors = [];
+
+        var valueRead = function (data) {
+          var descriptor = this;
+
+          sendEvent({
+            type: 'valueRead',
+            peripheralUuid: peripheral.uuid,
+            serviceUuid: service.uuid,
+            characteristicUuid: characteristic.uuid,
+            descriptorUuid: descriptor.uuid,
+            data: data.toString('hex')
+          });
+        };
+
+        var valueWrite = function (data) {
+          var descriptor = this;
+
+          sendEvent({
+            type: 'valueWrite',
+            peripheralUuid: peripheral.uuid,
+            serviceUuid: service.uuid,
+            characteristicUuid: characteristic.uuid,
+            descriptorUuid: descriptor.uuid
+          });
+        };
+
+        for (var k in descriptors) {
+          descriptors[k].on('valueRead', valueRead);
+
+          descriptors[k].on('valueWrite', valueWrite);
+
+          discoveredDescriptors.push(descriptors[k].uuid);
+        }
+
+        sendEvent({
+          type: 'descriptorsDiscover',
+          peripheralUuid: peripheral.uuid,
+          serviceUuid: service.uuid,
+          characteristicUuid: this.uuid,
+          descriptors: discoveredDescriptors
+        });
+      };
+
+      for (var j = 0; j < characteristics.length; j++) {
+        characteristics[j].on('read', read);
+
+        characteristics[j].on('write', write);
+
+        characteristics[j].on('broadcast', broadcast);
+
+        characteristics[j].on('notify', notify);
+
+        characteristics[j].on('descriptorsDiscover', descriptorsDiscover);
+
+        discoveredCharacteristics.push({
+          uuid: characteristics[j].uuid,
+          properties: characteristics[j].properties
+        });
+      }
+
+      sendEvent({
+        type: 'characteristicsDiscover',
+        peripheralUuid: peripheral.uuid,
+        serviceUuid: this.uuid,
+        characteristics: discoveredCharacteristics
+      });
+    };
+
+    for (var i in services) {
+      services[i].on('includedServicesDiscover', includedServicesDiscover);
+
+      services[i].on('characteristicsDiscover', characteristicsDiscover);
+
+      serviceUuids.push(services[i].uuid);
+    }
+
+    sendEvent({
+      type: 'servicesDiscover',
+      peripheralUuid: this.uuid,
+      serviceUuids: serviceUuids
+    });
+  });
+
+  peripheral.on('handleRead', function (handle, data) {
+    sendEvent({
+      type: 'handleRead',
+      peripheralUuid: this.uuid,
+      handle: handle,
+      data: data.toString('hex')
+    });
+  });
+
+  peripheral.on('handleWrite', function (handle) {
+    sendEvent({
+      type: 'handleWrite',
+      peripheralUuid: this.uuid,
+      handle: handle
+    });
+  });
+
+  peripheral.on('handleNotify', function (handle, data) {
+    sendEvent({
+      type: 'handleNotify',
+      peripheralUuid: this.uuid,
+      handle: handle,
+      data: data.toString('hex')
+    });
+  });
+
+  sendEvent({
+    type: 'discover',
+    peripheralUuid: peripheral.uuid,
+    address: peripheral.address,
+    addressType: peripheral.addressType,
+    connectable: peripheral.connectable,
+    advertisement: {
+      localName: peripheral.advertisement.localName,
+      txPowerLevel: peripheral.advertisement.txPowerLevel,
+      serviceUuids: peripheral.advertisement.serviceUuids,
+      manufacturerData: (peripheral.advertisement.manufacturerData ? peripheral.advertisement.manufacturerData.toString('hex') : null),
+      serviceData: (peripheral.advertisement.serviceData ? peripheral.advertisement.serviceData.toString('hex') : null)
+    },
+    rssi: peripheral.rssi
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "module": "system",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
+    "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */


### PR DESCRIPTION
In preparation of a possible BLE gateway implementation I have enabled noble's websocket support.

For testing:

1. start the server by running `WEBSOCKET_PORT=2846 npm run server-tool` on the "gateway" machine. This will start the noble websocket server on port 2846.
2. run the desired example command and prefix it with the following env variables:
  - `WEBSOCKET_ENABLE=1` - this will enable websocket support
  - `WEBSOCKET_HOST=127.0.0.1` - the IP or hostname of the host running the server
  - `WEBSOCKET_PORT=2846` - the port the server is running on

For example:
```sh
pi@raspberrypi:~/ttlock-sdk-js $ WEBSOCKET_ENABLE=1 WEBSOCKET_HOST=192.168.1.42 npm run get-cards
```

For the moment only one such remote gateway connection is supported, but it should be possible to implement multiple such connections in the future.